### PR TITLE
Add carbon intensity metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build
+api.txt

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Clarke
 
 Clarke tries to work out how much energy your machine is using, perhaps also how much carbon too and then ships that data off to somewhere so you can work out how to minimise it and then offset the residual.
 
+The tool is named after [Edith Clarke](https://en.wikipedia.org/wiki/Edith_Clarke).
+
+Clarke also integrates with Prometheus. Passing `--listen-prometheus=<port>` will start a prometheus server on port `<port>`.
+
 ## Energy Information Sources
 
 Calculating energy information for an arbitrary machine is challenging. Clarke currently offers three approximations:
@@ -15,7 +19,7 @@ Calculating energy information for an arbitrary machine is challenging. Clarke c
 
 None are perfect and more than likely they are all going to under-approximate the amount of energy used.
 
-The tool is named after [Edith Clarke](https://en.wikipedia.org/wiki/Edith_Clarke).
+The tool is also primarily focused on calculating emissions. It integrates the [carbon-intensity](https://github.com/geocaml/carbon-intensity) tool to also monitor the carbon intensity of the energy in the country where the computer is located. You can provide two arguments to control this. `--country` takes an ISO3061 alpha-2 code for the country and `--api` is the path to a file containing the [co2-signal](https://www.co2signal.com) API key. Note if you use `GB` as your code, you won't need to provide an API key.
 
 ## Typical Usage
 
@@ -40,6 +44,7 @@ For slightly more accurate information you can use the [variorum](https://github
 clarke monitor --meter=variorum
 ```
 
-### Prometheus Support
+### IPMI
 
-Clarke also integrates with Prometheus. Passing `--listen-prometheus=<port>` will start a prometheus server on port `<port>`.
+The Intelligent Platform Management Interface (IPMI) is another way we can query information about the power usage of a computer, or usually in this case a server. Using `--meter=ipmi` will try to use `ipmi-tool` to query sensors for power consumption statistics.
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Calculating energy information for an arbitrary machine is challenging. Clarke c
 
 None are perfect and more than likely they are all going to under-approximate the amount of energy used.
 
-The tool is also primarily focused on calculating emissions. It integrates the [carbon-intensity](https://github.com/geocaml/carbon-intensity) tool to also monitor the carbon intensity of the energy in the country where the computer is located. You can provide two arguments to control this. `--country` takes an ISO3061 alpha-2 code for the country and `--api` is the path to a file containing the [co2-signal](https://www.co2signal.com) API key. Note if you use `GB` as your code, you won't need to provide an API key.
+The tool is also primarily focused on calculating emissions. It integrates the [carbon-intensity](https://github.com/geocaml/carbon-intensity) tool to also monitor the carbon intensity of the energy in the country where the computer is located. You can provide two arguments to control this. `--country` takes an ISO3166 alpha-2 code for the country and `--api` is the path to a file containing the [co2-signal](https://www.co2signal.com) API key. Note if you use `GB` as your code, you won't need to provide an API key.
 
 ## Typical Usage
 

--- a/clarke.opam
+++ b/clarke.opam
@@ -28,5 +28,6 @@ pin-depends: [
   [ "eio.dev" "git+https://github.com/patricoferris/eio#6e681fec1f5894c29c28a042ab107675dd0fd518" ]
   [ "eio_luv.dev" "git+https://github.com/patricoferris/eio#6e681fec1f5894c29c28a042ab107675dd0fd518" ]
   [ "variorum.dev" "git+https://github.com/patricoferris/ocaml-variorum#9128770e9df08ca7a90f317acc08b9cd49da6766" ]
+  [ "ISO3166.dev" "git+https://github.com/geocaml/ISO3166#425ce3790f8e0a94ad31dd3ff6033463d645b3db" ]
   [ "carbon.dev" "git+https://github.com/geocaml/carbon-intensity#2d9e7b0376584fcf931f7847d32acfcde8a0b83c" ]
 ]

--- a/clarke.opam
+++ b/clarke.opam
@@ -20,6 +20,7 @@ depends: [
   "lwt_eio"
   "prometheus"
   "prometheus-app"
+  "carbon"
 ]
 pin-depends: [
   [ "hwloc.dev" "git+https://github.com/patricoferris/ocaml-hwloc#3447dc5c40f0d868529aafcc84b5d2d971062b30" ]
@@ -27,4 +28,5 @@ pin-depends: [
   [ "eio.dev" "git+https://github.com/patricoferris/eio#6e681fec1f5894c29c28a042ab107675dd0fd518" ]
   [ "eio_luv.dev" "git+https://github.com/patricoferris/eio#6e681fec1f5894c29c28a042ab107675dd0fd518" ]
   [ "variorum.dev" "git+https://github.com/patricoferris/ocaml-variorum#9128770e9df08ca7a90f317acc08b9cd49da6766" ]
+  [ "carbon.dev" "git+https://github.com/geocaml/carbon-intensity#2d9e7b0376584fcf931f7847d32acfcde8a0b83c" ]
 ]

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -1,4 +1,11 @@
 (executable
  (name main)
  (public_name clarke)
- (libraries eio_luv eio.unix clarke cmdliner clarke.prometheus-eio))
+ (libraries
+  eio_luv
+  eio.unix
+  clarke
+  cmdliner
+  clarke.prometheus-eio
+  logs.cli
+  fmt.cli))

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -1,6 +1,16 @@
 open Eio
 open Clarke
 
+(* Adding a metric for a carbon intensity gauge *)
+module Metrics = struct
+  let namespace = "Clarke"
+  let subsystem = "meter"
+
+  let carbon_intensity =
+    let help = "Current carbon intensity in gCO2/kWh" in
+    Prometheus.Gauge.v ~help ~namespace ~subsystem "intensity"
+end
+
 let with_socket ~sw net v fn =
   let listener = Net.listen ~sw ~backlog:5 net v in
   while true do
@@ -74,34 +84,118 @@ let meter_spec_term =
   @@ Arg.info [ "m"; "meter" ]
 
 let output_spec_term =
-  Arg.value @@ Arg.opt Specs.output_spec `Stdout @@ Arg.info [ "o"; "output" ]
+  Arg.value
+  @@ Arg.opt Specs.output_spec `Stdout
+  @@ Arg.info ~doc:"The output location of the monitoring data"
+       [ "o"; "output" ]
 
-let period_term = Arg.value @@ Arg.opt Arg.int 5 @@ Arg.info [ "p"; "period" ]
+let period_term =
+  Arg.value @@ Arg.opt Arg.int 5
+  @@ Arg.info ~doc:"The frequency in seconds for monitoring the power usage"
+       [ "p"; "period" ]
+
+let country_code =
+  let of_string s =
+    try Ok (ISO3166.alpha2_of_string (String.uppercase_ascii s))
+    with _ -> Error (`Msg "Unknown country code")
+  in
+  let pp ppf v = Fmt.pf ppf "%s" (ISO3166.alpha2_to_string v) in
+  Cmdliner.Arg.conv (of_string, pp)
+
+let country_code_term =
+  Arg.value
+  @@ Arg.opt (Arg.some country_code) None
+  @@ Arg.info ~doc:"The country code (alpha2) for carbon intensity calculations"
+       [ "c"; "country" ]
+
+let api_term =
+  Arg.value
+  @@ Arg.opt Arg.(some string) None
+  @@ Arg.info ~doc:"A file containing the CO2-Signal API code" [ "co2-signal" ]
+
+let update_info_with_intensity intensity info =
+  let watts = Info.watts info in
+  let timestamp = Info.timestamp info in
+  Info.v ?intensity timestamp watts
+
+let get_intensity ?country ?api_code net =
+  let open Carbon in
+  match (country, api_code) with
+  | None, None -> None
+  | Some code, None ->
+      if `GB = code then
+        Carbon.Gb.get_intensity net
+        |> Carbon.Gb.Intensity.actual |> Option.map float_of_int
+      else (
+        Logs.warn (fun f ->
+            f "Skipping carbon intensity for %s"
+              (ISO3166.alpha2_to_country code |> ISO3166.Country.name));
+        None)
+  | Some country_code, Some api ->
+      Logs.info (fun f ->
+          f "Calculating carbon intensity for %s"
+            (ISO3166.alpha2_to_string country_code));
+      let v = Carbon.Co2_signal.v api in
+      let i = Co2_signal.get_intensity ~net v ~country_code in
+      Co2_signal.Intensity.intensity i |> float_of_int |> Option.some
+  | _ -> None
+
+let setup_log style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level level;
+  Logs.Src.set_level Clarke.log_src level;
+  Logs.set_reporter (Logs_fmt.reporter ());
+  ()
+
+let setup_log =
+  let docs = Manpage.s_common_options in
+  Term.(
+    const setup_log $ Fmt_cli.style_renderer ~docs () $ Logs_cli.level ~docs ())
 
 let monitor ~env ~stdout ~net ~clock =
-  let run output meter period prom =
+  let run () output meter period prom country api_code =
+    let api_code =
+      Option.map (fun f -> Path.(load (env#fs / f) |> String.trim)) api_code
+    in
+    let get_intensity () =
+      let i = get_intensity ?country ?api_code net in
+      Option.iter (Prometheus.Gauge.set Metrics.carbon_intensity) i;
+      i
+    in
+    Logs.info (fun f -> f "Monitoring...");
     Switch.run @@ fun sw ->
+    let intensity = ref (get_intensity ()) in
     let (S.Meter ((module M), t) : S.meter) =
       Specs.meter_of_meter_spec ~clock meter
     in
     if not M.supported then Error "Unsupported meter choice, consult the manual"
     else (
-      Fiber.both (Prometheus_eio.serve env prom) (fun () ->
-          Specs.with_sink ~sw ~stdout ~net output (fun sink ->
-              while true do
-                let info = M.collect t in
-                Outputs.Flow.send sink info;
-                Prometheus.Gauge.set Clarke.Metrics.watts (Info.watts info);
-                Eio.Flow.copy_string "\n" sink;
-                Eio_unix.sleep (float_of_int period)
-              done));
+      Fiber.all
+        [
+          Prometheus_eio.serve env prom;
+          (fun () ->
+            while true do
+              Eio_unix.sleep (30. *. 60.);
+              intensity := get_intensity ()
+            done);
+          (fun () ->
+            Specs.with_sink ~sw ~stdout ~net output (fun sink ->
+                while true do
+                  let info = M.collect t in
+                  let info = update_info_with_intensity !intensity info in
+                  Outputs.Flow.send sink info;
+                  Prometheus.Gauge.set Clarke.Metrics.watts (Info.watts info);
+                  Eio.Flow.copy_string "\n" sink;
+                  Eio_unix.sleep (float_of_int period)
+                done));
+        ];
       Ok ())
   in
   let info = Cmd.info "monitor" in
   Cmd.v info
     Term.(
-      const run $ output_spec_term $ meter_spec_term $ period_term
-      $ Prometheus_eio.opts)
+      const run $ setup_log $ output_spec_term $ meter_spec_term $ period_term
+      $ Prometheus_eio.opts $ country_code_term $ api_term)
 
 let cmds env = [ monitor ~env ~stdout:env#stdout ~net:env#net ~clock:env#clock ]
 

--- a/src/lib/clarke.ml
+++ b/src/lib/clarke.ml
@@ -1,3 +1,5 @@
+let log_src = Log.src
+
 module S = S
 module Info = Info
 module Models = Models

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name clarke)
  (public_name clarke)
- (libraries eio_luv eio.unix ptime variorum ezjsonm prometheus))
+ (libraries eio_luv eio.unix ptime variorum ezjsonm prometheus carbon))

--- a/src/lib/info.mli
+++ b/src/lib/info.mli
@@ -1,7 +1,8 @@
 type t
 
-val v : Ptime.t -> float -> t
+val v : ?intensity:float -> Ptime.t -> float -> t
 val watts : t -> float
 val timestamp : t -> Ptime.t
+val intensity : t -> float option
 val pp : Format.formatter -> t -> unit
 val to_json : t -> string

--- a/src/lib/log.ml
+++ b/src/lib/log.ml
@@ -1,0 +1,4 @@
+let src =
+  Logs.Src.create "clarke" ~doc:"Clarke power and carbon monitoring system"
+
+include (val Logs.src_log src : Logs.LOG)

--- a/src/prometheus-eio/prometheus_eio.ml
+++ b/src/prometheus-eio/prometheus_eio.ml
@@ -135,7 +135,7 @@ module Logging = struct
 end
 
 (* Largely based on the other implementations of Prometheus servers:
-   
+
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
This PR integrate the carbon intensity tool to allow Clarke to also monitor power intensity metrics and report them along with the information for energy use.