### PR TITLE
Add lower-bound to extunix

### DIFF
--- a/clarke.opam
+++ b/clarke.opam
@@ -30,6 +30,7 @@ depends: [
   "carbon"
   "capnp-rpc-lwt"
   "capnp-rpc-unix"
+  "extunix" {>= "0.4.1"}
   "capnp" {>= "3.5.0"}
   "cohttp-eio" {>= "6.0.0~alpha1"}
   "eio" {>= "0.10"}

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
    carbon
    capnp-rpc-lwt
    capnp-rpc-unix
+  (extunix (>= 0.4.1))
   (capnp (>= 3.5.0))
   (cohttp-eio (>= 6.0.0~alpha1))
   (eio (>= 0.10))


### PR DESCRIPTION
Should allow the `(lower-bound)` lint check to pass in CI.